### PR TITLE
fix: qualify local reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       },
       "optionalDependencies": {
         "major": {
-          "extends": [":semanticCommitType(fix)", ":semanticBreakingChangeMessage"]
+          "extends": [":semanticCommitType(fix)", "smart-semantic-release:semanticBreakingChangeMessage"]
         },
         "minor": {
           "extends": ":semanticCommitType(chore)"
@@ -37,7 +37,7 @@
       },
       "peerDependencies": {
         "major": {
-          "extends": [":semanticCommitType(fix)", ":semanticBreakingChangeMessage"]
+          "extends": [":semanticCommitType(fix)", "smart-semantic-release:semanticBreakingChangeMessage"]
         },
         "minor": {
           "extends": ":semanticCommitType(chore)"


### PR DESCRIPTION
"naked" preset references like `:x` always may to `default:x` and not to `<this>:x`